### PR TITLE
Fix/ notification push

### DIFF
--- a/Back-project/Changelog.md
+++ b/Back-project/Changelog.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.2.2] - 2025-09-07
+### Added
+- test(auth): helper reutilizable de tokens `tests/auth/token.ts` con:
+  - `getAdminToken()`, `getToken(role)`, `withAuth(req, token)`, `clearCachedTokens()`.
+
+### Changed
+- ticket(update): `UpdateTicketInput` se **restringe** a `{ status, priority, assigned_user_id }`.  
+  `closed_at` ahora es **solo calculado** por el servicio (al cerrar/reabrir).
+- ticket(service): `update` corre en **transacción**, registra `StatusHistory` con `updatedAt` y retorna el `id` para recargar el ticket **tras el commit** (evita lecturas sucias en tests).
+- tests(ticket PUT): ya **no** envía `titulo` ni otros campos; valida cierre/reapertura y `closed_at`.
+- tests(suites): suites protegidas usan el helper de token, eliminando firmas JWT duplicadas.
+
+### Removed
+- ticket(update): se elimina actualizar vía API los campos  
+  `titulo`, `description`, `department_id`, `device_id`, `parent_ticket_id` y `closed_at`.
+
+### Fixed
+- attachments(service): se quita el **fanout de notificaciones** al crear adjuntos; solo persiste y devuelve el adjunto con relaciones.
+
+---
+
 ## [0.2.1] - 2025-09-04
 ### Added
 - test(helpers): fábrica de usuario vía `/api/users` + firmador JWT (HS256) para usar en suites de tickets.
@@ -14,7 +35,6 @@
 - ticket(create): error **500** por columna faltante — alineado modelo/BD para `created_by_email` en entorno de test (migración/sync aplicada).
 - tests(delete): uso de **UUID v4** válido para casos 404; estados esperados corregidos (204/404).
 - tests(setup): limpieza en orden respetando FKs para evitar violaciones durante los tests.
-
 
 ## [0.2.0] - 2025-09-03
 ### Added

--- a/Back-project/src/app.ts
+++ b/Back-project/src/app.ts
@@ -5,7 +5,7 @@ import path from "path";
 import passport from "passport";
 import { setupSwagger } from "./config/swagger";
 import routes from "./routes";
-import "./config/passport";
+import { configurePassport } from "./config/passport"; 
 import errorHandler from "./middleware/errorHandler";
 
 dotenv.config({
@@ -18,13 +18,15 @@ const app: Application = express();
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use("/uploads", express.static(path.join(__dirname, "uploads")));
+
 if (process.env.NODE_ENV !== "test") {
   app.use(morgan("dev"));
 }
 
+configurePassport();
 app.use(passport.initialize());
-setupSwagger(app);
 
+setupSwagger(app);
 app.use("/api", routes);
 
 app.use(errorHandler);

--- a/Back-project/src/controllers/auth.controller.ts
+++ b/Back-project/src/controllers/auth.controller.ts
@@ -4,9 +4,11 @@ import jwt from "jsonwebtoken";
 import { UnauthorizedError, InternalServerError } from "../utils/error";
 
 export class AuthController {
-
   static googleAuth(req: Request, res: Response, next: NextFunction) {
-    passport.authenticate("google-user", { scope: ["profile", "email"] })(req, res, next);
+    passport.authenticate("google-user", {
+      scope: ["profile", "email"],
+      prompt: "consent select_account",
+    })(req, res, next);
   }
 
   static googleAuthCallback(req: Request, res: Response, next: NextFunction) {
@@ -14,8 +16,14 @@ export class AuthController {
       "google-user",
       { session: false },
       (err: Error | null, user: any, info?: any) => {
-        if (err) return next(new InternalServerError("Error en autenticación con Google"));
-        if (!user) return next(new UnauthorizedError(info?.message || "Autenticación fallida"));
+        if (err)
+          return next(
+            new InternalServerError("Error en autenticación con Google")
+          );
+        if (!user)
+          return next(
+            new UnauthorizedError(info?.message || "Autenticación fallida")
+          );
 
         try {
           const payload = {
@@ -25,7 +33,8 @@ export class AuthController {
           };
 
           const secret = process.env.JWT_SECRET;
-          if (!secret) throw new InternalServerError("JWT_SECRET no está definido");
+          if (!secret)
+            throw new InternalServerError("JWT_SECRET no está definido");
 
           const token = jwt.sign(payload, secret, { expiresIn: "1h" });
 
@@ -38,26 +47,41 @@ export class AuthController {
   }
 
   static googleAdminAuth(req: Request, res: Response, next: NextFunction) {
-    passport.authenticate("google-admin", { scope: ["profile", "email"] })(req, res, next);
+    passport.authenticate("google-admin", {
+      scope: ["profile", "email"],
+      prompt: "consent select_account",
+    })(req, res, next);
   }
 
-  static googleAdminAuthCallback(req: Request, res: Response, next: NextFunction) {
+  static googleAdminAuthCallback(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ) {
     passport.authenticate(
       "google-admin",
       { session: false },
       (err: Error | null, user: any, info?: any) => {
-        if (err) return next(new InternalServerError("Error en autenticación con Google"));
-        if (!user) return next(new UnauthorizedError(info?.message || "Autenticación fallida"));
+        if (err)
+          return next(
+            new InternalServerError("Error en autenticación con Google")
+          );
+        if (!user)
+          return next(
+            new UnauthorizedError(info?.message || "Autenticación fallida")
+          );
 
         try {
           const payload = {
             id: user.user_id,
+            name: user.name,
             email: user.email,
             role: user.role,
           };
 
           const secret = process.env.JWT_SECRET;
-          if (!secret) throw new InternalServerError("JWT_SECRET no está definido");
+          if (!secret)
+            throw new InternalServerError("JWT_SECRET no está definido");
 
           const token = jwt.sign(payload, secret, { expiresIn: "1h" });
 

--- a/Back-project/src/models/ticket.model.ts
+++ b/Back-project/src/models/ticket.model.ts
@@ -16,7 +16,7 @@ interface TicketAttributes {
   department_id: number;
   parent_ticket_id?: string | null;
   created_by_id?: string | null;
-  created_by_name: string;
+  created_by_name: string | null;
   created_by_email?: string | null;
 
   createdAt?: Date;
@@ -61,7 +61,7 @@ class Ticket
   public department_id!: number;
   public parent_ticket_id!: string | null;
   public created_by_id!: string | null;
-  public created_by_name!: string;
+  public created_by_name!: string | null;
   public created_by_email!: string | null;
 
   public readonly createdAt!: Date;

--- a/Back-project/src/models/user.model.ts
+++ b/Back-project/src/models/user.model.ts
@@ -12,7 +12,7 @@ interface UserAttributes {
   password?: string | null;
   phone_number?: string | null;
   status: UserStatus;
-  company: CompanyType;
+  company: CompanyType | null;
   role: UserRole;
   provider?: string | null;
   provider_id?: string | null;
@@ -157,11 +157,11 @@ User.init(
     },
     status: {
       type: DataTypes.ENUM(...Object.values(UserStatus)),
-      allowNull: false,
+      allowNull: true,
     },
     company: {
       type: DataTypes.ENUM(...Object.values(CompanyType)),
-      allowNull: false,
+      allowNull: true,
     },
     role: {
       type: DataTypes.ENUM(...Object.values(UserRole)),

--- a/Back-project/src/routes/index.ts
+++ b/Back-project/src/routes/index.ts
@@ -4,6 +4,7 @@ import DeviceTypeRoutes from "./deviceType.routes";
 import UserRoutes from "./users.routes";
 import DeviceRoutes from "./devices.routes";
 import TicketRoutes from "./tickets.routes";
+import AuthRoutes from "./auth.routes";
 
 const router = Router();
 
@@ -12,5 +13,6 @@ router.use("/device-types", DeviceTypeRoutes);
 router.use("/devices", DeviceRoutes);
 router.use("/users", UserRoutes);
 router.use("/tickets", TicketRoutes);
+router.use("/auth", AuthRoutes);
 
 export default router;

--- a/Back-project/src/services/ticket.service.ts
+++ b/Back-project/src/services/ticket.service.ts
@@ -15,6 +15,7 @@ import { StatusHistoryService } from "./statusHistory.service";
 import { NotificationService } from "./notification.service";
 import { NotificationType } from "../enums/notificationType.enum";
 import { UserRole } from "../enums/userRole.enum";
+import { sequelize } from "../config/sequelize";
 
 const SORT_MAP: Record<string, "titulo" | "status" | "priority" | "createdAt"> =
   {
@@ -22,35 +23,38 @@ const SORT_MAP: Record<string, "titulo" | "status" | "priority" | "createdAt"> =
     status: "status",
     priority: "priority",
     createdAt: "createdAt",
-  };
+  } as const;
+
+const shortId = (id: string) => id.substring(0, 8);
+
+async function adminsDeptYSistemas(
+  deptId: number,
+  includeAssignee?: string | null
+): Promise<string[]> {
+  const [deptAdmins, sistemasAdmins] = await Promise.all([
+    NotificationService.recipientsDeptAdmins(deptId),
+    NotificationService.recipientsDeptAllByName("Sistemas", {
+      roles: [UserRole.Administrador],
+      onlyActive: true,
+    }),
+  ]);
+  const set = new Set<string>([...deptAdmins, ...sistemasAdmins]);
+  if (includeAssignee) set.add(includeAssignee);
+  return Array.from(set);
+}
 
 export class TicketService {
   static async create(payload: CreateTicketInput) {
-    console.log("[TicketService.create] IN payload", {
-      titulo: payload.titulo,
-      department_id: payload.department_id,
-      status: payload.status,
-      priority: payload.priority,
-      assigned_user_id: payload.assigned_user_id,
-      device_id: payload.device_id,
-      parent_ticket_id: payload.parent_ticket_id,
-      created_by_id: payload.created_by_id,
-      created_by_name: payload.created_by_name,
-      created_by_email: payload.created_by_email,
-    });
-
     if (payload.status === TicketStatus.Cerrado) {
-      console.log("[TicketService.create] blocked: status=Cerrado");
       throw new BadRequestError(
         "No se permite crear un ticket con estado Cerrado."
       );
     }
 
     try {
-      console.log("[TicketService.create] Creating Ticket...");
       const row = await Ticket.create({
-        titulo: payload.titulo.trim(),
-        description: payload.description.trim(),
+        titulo: payload.titulo,
+        description: payload.description,
         status: payload.status,
         priority: payload.priority ?? null,
         device_id: payload.device_id ?? null,
@@ -59,77 +63,34 @@ export class TicketService {
         parent_ticket_id: payload.parent_ticket_id ?? null,
         closed_at: null,
         created_by_id: payload.created_by_id ?? null,
-        created_by_name: payload.created_by_name?.trim() ?? undefined,
-        created_by_email: payload.created_by_email?.trim() ?? null,
-      });
-      console.log("[TicketService.create] Created Ticket", {
-        ticket_id: row.ticket_id,
+        created_by_name: payload.created_by_name ?? null,
+        created_by_email: payload.created_by_email ?? null,
       });
 
-      console.log("[TicketService.create] notifyToDeptByName('Sistemas')...");
       await NotificationService.notifyToDeptByName(
         "Sistemas",
         {
           type: NotificationType.Informacion,
-          message: `Nuevo ticket creado (${row.ticket_id.substring(0, 8)}).`,
+          message: `Nuevo ticket creado (${shortId(row.ticket_id)}).`,
           ticket_id: row.ticket_id,
         },
         { roles: [UserRole.Administrador], onlyActive: true }
       );
-      console.log("[TicketService.create] notifyToDeptByName OK");
 
       if (!row.assigned_user_id) {
-        console.log(
-          "[TicketService.create] Ticket sin encargado, resolviendo recipients…",
-          {
-            department_id: row.department_id,
-          }
-        );
-        const [deptAdmins, sistemasAdmins] = await Promise.all([
-          NotificationService.recipientsDeptAdmins(row.department_id),
-          NotificationService.recipientsDeptAllByName("Sistemas", {
-            roles: [UserRole.Administrador],
-            onlyActive: true,
-          }),
-        ]);
-        const recipients = Array.from(
-          new Set([...deptAdmins, ...sistemasAdmins])
-        );
-        console.log("[TicketService.create] recipients resueltos", {
-          count: recipients.length,
-        });
-
+        const recipients = await adminsDeptYSistemas(row.department_id, null);
         if (recipients.length) {
-          console.log("[TicketService.create] createAndFanout...");
           await NotificationService.createAndFanout({
             type: NotificationType.Advertencia,
-            message: `Ticket sin encargado (${row.ticket_id.substring(0, 8)}).`,
+            message: `Ticket sin encargado (${shortId(row.ticket_id)}).`,
             ticket_id: row.ticket_id,
             recipients,
           });
-          console.log("[TicketService.create] createAndFanout OK");
-        } else {
-          console.log("[TicketService.create] sin recipients para notificar");
         }
       }
 
-      console.log("[TicketService.create] fetching withBasics", {
-        ticket_id: row.ticket_id,
-      });
       return await Ticket.scope(["withBasics"]).findByPk(row.ticket_id);
     } catch (error: any) {
-      console.error("[TicketService.create] ERROR", {
-        name: error?.name,
-        message: error?.message,
-        fields: error?.fields,
-        original: {
-          code: error?.original?.code,
-          detail: error?.original?.detail,
-          constraint: error?.original?.constraint,
-          table: error?.original?.table,
-        },
-      });
-
       if (error?.name === "SequelizeForeignKeyConstraintError") {
         const col = error?.fields ? Object.keys(error.fields)[0] : undefined;
         if (col === "device_id")
@@ -163,8 +124,8 @@ export class TicketService {
       } = params;
 
       const scopes: any[] = ["withBasics"];
-      if (search.trim()) {
-        scopes.push({ method: ["search", search.trim()] });
+      if (search) {
+        scopes.push({ method: ["search", search] });
       }
       const sortCol = SORT_MAP[sort] ?? "createdAt";
       const sortDir = order === "DESC" ? "DESC" : "ASC";
@@ -180,45 +141,26 @@ export class TicketService {
   }
 
   static async update(
-    id: string,
-    payload: UpdateTicketInput,
-    actorUserId?: string
-  ) {
-    try {
+  id: string,
+  payload: UpdateTicketInput,
+  actorUserId?: string
+) {
+  try {
+    const updatedId = await sequelize.transaction(async (t) => {
       const row = await this.findById(id);
-
-      if (
-        payload.parent_ticket_id !== undefined &&
-        payload.parent_ticket_id === id
-      ) {
-        throw new BadRequestError(
-          "parent_ticket_id no puede ser el mismo ticket."
-        );
-      }
 
       const prevStatus = row.status;
       const prevAssignee = row.assigned_user_id;
       const prevPriority = row.priority;
-      const prevDeptId = row.department_id;
 
-      if (payload.titulo !== undefined) row.titulo = payload.titulo.trim();
-      if (payload.description !== undefined)
-        row.description = payload.description.trim();
-      if (payload.status !== undefined)
-        row.status = payload.status as TicketStatus;
-      if (payload.priority !== undefined)
-        row.priority = (payload.priority ?? null) as TicketPriority | null;
-      if (payload.device_id !== undefined)
-        row.device_id = payload.device_id ?? null;
+      if (payload.status !== undefined) row.status = payload.status!;
+      if (payload.priority !== undefined) row.priority = payload.priority ?? null;
       if (payload.assigned_user_id !== undefined)
         row.assigned_user_id = payload.assigned_user_id ?? null;
-      if (payload.department_id !== undefined)
-        row.department_id = payload.department_id;
-      if (payload.parent_ticket_id !== undefined)
-        row.parent_ticket_id = payload.parent_ticket_id ?? null;
 
       const statusChanged =
         payload.status !== undefined && payload.status !== prevStatus;
+
       if (statusChanged) {
         if (payload.status === TicketStatus.Cerrado) {
           row.closed_at = new Date();
@@ -227,49 +169,47 @@ export class TicketService {
         }
       }
 
-      await row.save();
+      await row.save({ transaction: t });
 
       if (statusChanged && actorUserId) {
+        const occurredAt = row.updatedAt ?? new Date();
         await StatusHistoryService.logChange(
           row.ticket_id,
           prevStatus,
           row.status,
           actorUserId,
-          new Date()
+          occurredAt,
+          { transaction: t }
         );
       }
+
+      const runAfterCommit: Array<() => Promise<void>> = [];
 
       const assigneeChanged =
         payload.assigned_user_id !== undefined &&
         payload.assigned_user_id !== prevAssignee;
+
       if (assigneeChanged && row.assigned_user_id) {
-        await NotificationService.notifyAssignee(
-          row.ticket_id,
-          row.assigned_user_id
-        );
+        runAfterCommit.push(async () => {
+          await NotificationService.notifyAssignee(row.ticket_id, row.assigned_user_id!);
+        });
       }
 
       const priorityChanged =
         payload.priority !== undefined && payload.priority !== prevPriority;
-      if (priorityChanged && row.priority === TicketPriority.Critica) {
-        const [deptAdmins, sistemasAdmins] = await Promise.all([
-          NotificationService.recipientsDeptAdmins(row.department_id),
-          NotificationService.recipientsDeptAllByName("Sistemas", {
-            roles: [UserRole.Administrador],
-            onlyActive: true,
-          }),
-        ]);
-        const recipients = new Set<string>([...deptAdmins, ...sistemasAdmins]);
-        if (row.assigned_user_id) recipients.add(row.assigned_user_id);
 
-        await NotificationService.createAndFanout({
-          type: NotificationType.Alerta,
-          message: `Prioridad CRÍTICA en ticket ${row.ticket_id.substring(
-            0,
-            8
-          )}.`,
-          ticket_id: row.ticket_id,
-          recipients: Array.from(recipients),
+      if (priorityChanged && row.priority === TicketPriority.Critica) {
+        runAfterCommit.push(async () => {
+          const recipients = await adminsDeptYSistemas(
+            row.department_id,
+            row.assigned_user_id ?? null
+          );
+          await NotificationService.createAndFanout({
+            type: NotificationType.Alerta,
+            message: `Prioridad CRÍTICA en ticket ${shortId(row.ticket_id)}.`,
+            ticket_id: row.ticket_id,
+            recipients,
+          });
         });
       }
 
@@ -278,75 +218,61 @@ export class TicketService {
         prevStatus === TicketStatus.Cerrado &&
         row.status !== TicketStatus.Cerrado
       ) {
-        const [deptAdmins, sistemasAdmins] = await Promise.all([
-          NotificationService.recipientsDeptAdmins(row.department_id),
-          NotificationService.recipientsDeptAllByName("Sistemas", {
-            roles: [UserRole.Administrador],
-            onlyActive: true,
-          }),
-        ]);
-        const recipients = new Set<string>([...deptAdmins, ...sistemasAdmins]);
-        if (row.assigned_user_id) recipients.add(row.assigned_user_id);
-
-        await NotificationService.createAndFanout({
-          type: NotificationType.Advertencia,
-          message: `Ticket reabierto (${row.ticket_id.substring(0, 8)}).`,
-          ticket_id: row.ticket_id,
-          recipients: Array.from(recipients),
+        runAfterCommit.push(async () => {
+          const recipients = await adminsDeptYSistemas(
+            row.department_id,
+            row.assigned_user_id ?? null
+          );
+          await NotificationService.createAndFanout({
+            type: NotificationType.Advertencia,
+            message: `Ticket reabierto (${shortId(row.ticket_id)}).`,
+            ticket_id: row.ticket_id,
+            recipients,
+          });
         });
       }
 
       if (statusChanged && row.status === TicketStatus.Cerrado) {
-        const deptAdmins = await NotificationService.recipientsDeptAdmins(
-          row.department_id
-        );
-        const recipients = new Set<string>(deptAdmins);
-        if (row.assigned_user_id) recipients.add(row.assigned_user_id);
-
-        await NotificationService.createAndFanout({
-          type: NotificationType.Informacion,
-          message: `Ticket cerrado (${row.ticket_id.substring(0, 8)}).`,
-          ticket_id: row.ticket_id,
-          recipients: Array.from(recipients),
+        runAfterCommit.push(async () => {
+          const recipients = await adminsDeptYSistemas(
+            row.department_id,
+            row.assigned_user_id ?? null
+          );
+          await NotificationService.createAndFanout({
+            type: NotificationType.Informacion,
+            message: `Ticket cerrado (${shortId(row.ticket_id)}).`,
+            ticket_id: row.ticket_id,
+            recipients,
+          });
         });
       }
 
-      const deptChanged =
-        payload.department_id !== undefined &&
-        payload.department_id !== prevDeptId;
-      if (deptChanged) {
-        const newAdmins = await NotificationService.recipientsDeptAdmins(
-          row.department_id
-        );
-        if (newAdmins.length) {
-          await NotificationService.createAndFanout({
-            type: NotificationType.Informacion,
-            message: `Ticket movido de departamento.`,
-            ticket_id: row.ticket_id,
-            recipients: newAdmins,
-          });
-        }
-      }
+      t.afterCommit(async () => {
+        for (const job of runAfterCommit) await job();
+      });
 
-      return await this.findById(id);
-    } catch (error: any) {
-      if (error instanceof NotFoundError || error instanceof BadRequestError)
-        throw error;
-      if (error?.name === "SequelizeForeignKeyConstraintError") {
-        const col = error?.fields ? Object.keys(error.fields)[0] : undefined;
-        if (col === "device_id")
-          throw new BadRequestError("FK inválida: device_id no existe.");
-        if (col === "assigned_user_id")
-          throw new BadRequestError("FK inválida: assigned_user_id no existe.");
-        if (col === "department_id")
-          throw new BadRequestError("FK inválida: department_id no existe.");
-        if (col === "parent_ticket_id")
-          throw new BadRequestError("FK inválida: parent_ticket_id no existe.");
-        throw new BadRequestError("FK inválida en el ticket.");
-      }
-      throw new InternalServerError("Error al actualizar el ticket.");
+      return row.ticket_id;
+    });
+    return await this.findById(updatedId);
+  } catch (error: any) {
+    if (error instanceof NotFoundError || error instanceof BadRequestError)
+      throw error;
+    if (error?.name === "SequelizeForeignKeyConstraintError") {
+      const col = error?.fields ? Object.keys(error.fields)[0] : undefined;
+      if (col === "device_id")
+        throw new BadRequestError("FK inválida: device_id no existe.");
+      if (col === "assigned_user_id")
+        throw new BadRequestError("FK inválida: assigned_user_id no existe.");
+      if (col === "department_id")
+        throw new BadRequestError("FK inválida: department_id no existe.");
+      if (col === "parent_ticket_id")
+        throw new BadRequestError("FK inválida: parent_ticket_id no existe.");
+      throw new BadRequestError("FK inválida en el ticket.");
     }
+    throw new InternalServerError("Error al actualizar el ticket.");
   }
+}
+
 
   static async delete(id: string) {
     try {

--- a/Back-project/src/tests/auth/token.ts
+++ b/Back-project/src/tests/auth/token.ts
@@ -1,0 +1,57 @@
+import request, { Test as SupertestReq } from "supertest";
+import jwt from "jsonwebtoken";
+import app from "../../app";
+import { UserRole } from "../../enums/userRole.enum";
+
+const TEST_SECRET = process.env.JWT_SECRET || "test-secret";
+
+let cachedAdmin: { token: string; user_id: string } | null = null;
+
+function signToken(payload: {
+  user_id: string;
+  email: string;
+  name: string;
+  role: UserRole;
+}) {
+  return jwt.sign(payload, TEST_SECRET, { algorithm: "HS256" });
+}
+
+async function createUserForRole(role: UserRole) {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+  const first_name = role === UserRole.Administrador ? "Admin" : "User";
+  const last_name = "Test";
+  const email = `${first_name.toLowerCase()}.${unique}@example.com`;
+
+  const res = await request(app).post("/api/users").send({
+    first_name,
+    last_name,
+    email,
+    password: "secreto123",
+  });
+
+  const user_id = res.body.user_id as string;
+  const name = `${first_name} ${last_name}`;
+  const token = signToken({ user_id, email, name, role });
+
+  return { token, user_id };
+}
+
+export async function getAdminToken(reuse: boolean = true) {
+  if (reuse && cachedAdmin) return cachedAdmin.token;
+  const { token, user_id } = await createUserForRole(UserRole.Administrador);
+  if (reuse) cachedAdmin = { token, user_id };
+  return token;
+}
+
+export async function getToken(role: UserRole = UserRole.Estandar) {
+  const { token } = await createUserForRole(role);
+  return token;
+}
+
+export function withAuth<T extends SupertestReq>(req: T, token: string) {
+  return req.set("Authorization", `Bearer ${token}`);
+}
+
+export function clearCachedTokens() {
+  cachedAdmin = null;
+}

--- a/Back-project/src/types/ticket.types.ts
+++ b/Back-project/src/types/ticket.types.ts
@@ -16,15 +16,9 @@ export interface CreateTicketInput {
 }
 
 export interface UpdateTicketInput {
-  titulo?: string;
-  description?: string;
-  status?: TicketStatus;
+  status?: TicketStatus | null;
   priority?: TicketPriority | null;
-  device_id?: number | null;
   assigned_user_id?: string | null;
-  department_id?: number;
-  parent_ticket_id?: string | null;
-  closed_at?: Date | null;
 }
 
 export interface ListTicketsParams {

--- a/Back-project/src/types/user.types.ts
+++ b/Back-project/src/types/user.types.ts
@@ -1,4 +1,5 @@
 import { CompanyType } from "../enums/companyType.enum";
+import { UserRole } from "../enums/userRole.enum";
 
 export interface GoogleProfile {
   id: string;
@@ -12,11 +13,16 @@ export type CreateUserInput = {
   email: string;
   password: string;
   phone_number?: string;
+  company?: CompanyType | null;
+  department_id?: number;
+  role?: UserRole; 
 };
 
 export type UpdateUserProfileInput = {
   phone_number?: string;
   password?: string;
+  role?: UserRole;
+  email?: string;
   department_id?: number;  
   company?: CompanyType;
 };

--- a/Back-project/src/validators/ticket.validator.ts
+++ b/Back-project/src/validators/ticket.validator.ts
@@ -2,72 +2,125 @@ import { body, param, query } from "express-validator";
 import { TicketStatus } from "../enums/ticketStatus.enum";
 import { TicketPriority } from "../enums/ticketPriority.enum";
 
+const norm = (v: unknown) =>
+  typeof v === "string" ? v.trim().replace(/\s+/g, " ") : v;
+
+const nullIfEmpty = (v: unknown) =>
+  typeof v === "string" && v.trim() === "" ? null : v;
+
+const ALLOWED_SORT = ["titulo", "status", "priority", "createdAt"] as const;
+const ALLOWED_ORDER = ["ASC", "DESC"] as const;
+
 export const ticketCreateValidator = [
   body("titulo")
+    .customSanitizer(norm)
     .notEmpty()
     .isLength({ min: 3, max: 255 })
     .withMessage("El título debe tener entre 3 y 255 caracteres."),
-  body("description").notEmpty().withMessage("La descripción es obligatoria."),
+
+  body("description")
+    .customSanitizer(norm)
+    .notEmpty()
+    .withMessage("La descripción es obligatoria."),
+
   body("status")
     .notEmpty()
     .isIn(Object.values(TicketStatus))
     .withMessage("Estado inválido."),
+
   body("priority")
-    .optional()
+    .optional({ nullable: true })
     .isIn(Object.values(TicketPriority))
     .withMessage("Prioridad inválida."),
+
   body("device_id")
-    .optional()
+    .optional({ nullable: true })
     .isInt({ min: 1 })
-    .toInt()
-    .withMessage("device_id debe ser entero >= 1."),
+    .withMessage("device_id debe ser entero >= 1 o null.")
+    .toInt(),
+
   body("assigned_user_id")
-    .optional()
+    .optional({ nullable: true })
     .isUUID()
-    .withMessage("assigned_user_id debe ser UUID."),
+    .withMessage("assigned_user_id debe ser UUID o null."),
+
   body("department_id")
     .notEmpty()
     .isInt({ min: 1 })
-    .toInt()
-    .withMessage("department_id debe ser entero >= 1."),
+    .withMessage("department_id debe ser entero >= 1.")
+    .toInt(),
+
   body("parent_ticket_id")
-    .optional()
+    .optional({ nullable: true })
     .isUUID()
-    .withMessage("parent_ticket_id debe ser UUID."),
+    .withMessage("parent_ticket_id debe ser UUID o null."),
+
+  body("created_by_id")
+    .optional({ nullable: true })
+    .isUUID()
+    .withMessage("created_by_id debe ser UUID o null."),
+
+  body("created_by_name")
+    .optional({ nullable: true })
+    .customSanitizer(nullIfEmpty)
+    .customSanitizer(norm)
+    .isLength({ max: 255 })
+    .withMessage("created_by_name no debe exceder 255 caracteres."),
+
+  body("created_by_email")
+    .optional({ nullable: true })
+    .customSanitizer(nullIfEmpty)
+    .isEmail()
+    .withMessage("created_by_email debe ser un email válido o null.")
+    .normalizeEmail(),
 ];
 
 export const ticketUpdateValidator = [
   param("id").isUUID().withMessage("El ID del ticket debe ser un UUID válido."),
+
   body("titulo")
-    .optional()
+    .optional({ nullable: false })
+    .customSanitizer(norm)
     .isLength({ min: 3, max: 255 })
     .withMessage("El título debe tener entre 3 y 255 caracteres."),
+
+  body("description")
+    .optional({ nullable: false })
+    .customSanitizer(norm)
+    .isLength({ min: 1 })
+    .withMessage("La descripción no puede ir vacía."),
+
   body("status")
-    .optional()
+    .optional({ nullable: false })
     .isIn(Object.values(TicketStatus))
     .withMessage("Estado inválido."),
+
   body("priority")
-    .optional()
+    .optional({ nullable: true })
     .isIn(Object.values(TicketPriority))
     .withMessage("Prioridad inválida."),
+
   body("device_id")
-    .optional()
+    .optional({ nullable: true })
     .isInt({ min: 1 })
-    .toInt()
-    .withMessage("device_id debe ser entero >= 1."),
+    .withMessage("device_id debe ser entero >= 1 o null.")
+    .toInt(),
+
   body("assigned_user_id")
-    .optional()
+    .optional({ nullable: true })
     .isUUID()
-    .withMessage("assigned_user_id debe ser UUID."),
+    .withMessage("assigned_user_id debe ser UUID o null."),
+
   body("department_id")
-    .optional()
+    .optional({ nullable: false })
     .isInt({ min: 1 })
-    .toInt()
-    .withMessage("department_id debe ser entero >= 1."),
+    .withMessage("department_id debe ser entero >= 1.")
+    .toInt(),
+
   body("parent_ticket_id")
-    .optional()
+    .optional({ nullable: true })
     .isUUID()
-    .withMessage("parent_ticket_id debe ser UUID."),
+    .withMessage("parent_ticket_id debe ser UUID o null."),
 ];
 
 export const ticketIdValidator = [
@@ -75,23 +128,35 @@ export const ticketIdValidator = [
 ];
 
 export const ticketListValidator = [
-  query("search").optional().isString().withMessage("search debe ser texto."),
+  query("search")
+    .optional({ nullable: true })
+    .customSanitizer(nullIfEmpty)
+    .customSanitizer(norm)
+    .isString()
+    .withMessage("search debe ser texto."),
+
   query("limit")
-    .optional()
+    .optional({ nullable: true })
     .isInt({ min: 1, max: 200 })
-    .toInt()
-    .withMessage("limit debe ser 1..200."),
+    .withMessage("limit debe ser 1..200.")
+    .toInt(),
+
   query("offset")
-    .optional()
+    .optional({ nullable: true })
     .isInt({ min: 0 })
-    .toInt()
-    .withMessage("offset debe ser >= 0."),
+    .withMessage("offset debe ser >= 0.")
+    .toInt(),
+
   query("sort")
-    .optional()
-    .isIn(["titulo", "status", "priority", "createdAt"])
+    .optional({ nullable: true })
+    .isIn(ALLOWED_SORT as unknown as string[])
     .withMessage("sort inválido."),
+
   query("order")
-    .optional()
-    .isIn(["ASC", "DESC"])
+    .optional({ nullable: true })
+    .customSanitizer((v) =>
+      typeof v === "string" ? v.toUpperCase() : v
+    )
+    .isIn(ALLOWED_ORDER as unknown as string[])
     .withMessage("order debe ser ASC o DESC."),
 ];

--- a/Back-project/src/validators/user.validator.ts
+++ b/Back-project/src/validators/user.validator.ts
@@ -29,7 +29,7 @@ export const userCreateValidator = [
     .isLength({ min: 1, max: 50 })
     .withMessage("last_name es requerido (1-50 caracteres)"),
 
-  body("email").trim().normalizeEmail().isEmail().withMessage("email inválido"),
+  body("email").trim().toLowerCase().normalizeEmail().isEmail().withMessage("email inválido"),
 
   body("password")
     .trim()


### PR DESCRIPTION
feat(auth,test,tickets): helper de tokens; update transaccional; quitar notificaciones en adjuntos

- test(auth): agrega `tests/auth/token.ts` con `getAdminToken()`, `getToken(role)`,
  `withAuth(req, token)` y caché simple para reutilizar el JWT en suites.
- tests: actualiza suites (POST/GET/PUT/DELETE de tickets) para usar el helper y
  enviar `Authorization: Bearer <token>` en todas las requests protegidas.
- tickets(service): `update` ahora corre en transacción, registra `StatusHistory`
  con `updatedAt`, devuelve el id y recarga el ticket tras el commit para evitar
  lecturas sucias en tests.
- tickets(dto): `UpdateTicketInput` restringido a `{ status, priority, assigned_user_id }`;
  `closed_at` se calcula automáticamente al cerrar/reabrir.
- attachments(service): elimina fanout de notificaciones al crear adjuntos.